### PR TITLE
Fix for crash 

### DIFF
--- a/Classes/ARTiledImageView.m
+++ b/Classes/ARTiledImageView.m
@@ -168,6 +168,10 @@ static NSInteger maxRetry = 25;
         ARTile *tile = [urls objectForKey:tileKey];
         NSURL *tileUrl = tile.tileURL;
         
+        if (!tileUrl) {
+            return;
+        }
+        
         @synchronized (self.downloadOperations) {
             if ([self.downloadOperations objectForKey:tileKey]) {
                 continue;


### PR DESCRIPTION
- *** -[__NSDictionaryM setObject:forKey:]: object cannot be nil (key: 12/3_3)
I tested this fix in the Ancestry app, and with the change, the crash doesn't happen and the images are still displayed.